### PR TITLE
Expose web-root with docker volume on host system

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,8 @@ services:
   wordpress:
     image: tsertkov/wp-headless:${WORDPRESS_VERSION}
     restart: unless-stopped
+    volumes:
+      - ./var/wordpress:/var/www/html
     ports:
       - "80:80"
     depends_on:

--- a/var/.gitignore
+++ b/var/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
- `var/` folder introduced to be used for runtime data which survives container and volumes removal
- `var/wordpress` mapped to webroot folder `/var/www/html` with wordpress files