### PR TITLE
Remove redundant amazon-web-services plugin

### DIFF
--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -14,7 +14,6 @@ services:
           custom-post-type-ui 1.5.7
           acf-to-rest-api 3.1.0
           amazon-s3-and-cloudfront 1.3.2
-          amazon-web-services 1.0.5
           wordpress-importer 0.6.4
           jwt-authentication-for-wp-rest-api 1.2.4
           multisite-admin-bar-switcher 1.2.6


### PR DESCRIPTION
See https://deliciousbrains.com/wp-offload-s3-1-6-released/?utm_medium=insideplugin&utm_source=OS3%2BFree&utm_campaign=support%2Bdocs&utm_content=os3%2Bsettings%2Baws%2Bactive